### PR TITLE
Fix Roslyn Tests and downgrade to use .NET6.0 instead of .NET8.0 (lowers code requirements).

### DIFF
--- a/ExportErrorMessages/ExportErrorMessages.csproj
+++ b/ExportErrorMessages/ExportErrorMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ExportErrorMessages</RootNamespace>


### PR DESCRIPTION
Fixes Roslyn Unit Tests to find the location of the .sln dynamically. Fixes Roslyn Unit Tests to accept ProtocolTests(net472) as a project Name.