### PR TITLE
Improve check 2.46: CheckIndexAttribute on Param.ArrayOptions

### DIFF
--- a/Protocol/Error Messages/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
+++ b/Protocol/Error Messages/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
@@ -29,7 +29,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Missing attribute '{0}' in {1} '{2}'.", "index", "table", tablePid),
                 HowToFix = "Add the attribute with value 0.",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,
@@ -54,7 +54,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Empty attribute '{0}' in {1} '{2}'.", "index", "table", tablePid),
                 HowToFix = " Add the attribute with value 0.",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,
@@ -79,7 +79,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Unsupported attribute '{0}' in {1} '{2}'. Current value '{3}'.", "index", "table", tablePid, currentValue),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -104,7 +104,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Reference to non-existing column with IDX '{0}' in attribute 'index'. Table ID '{1}'.", indexValue, tablePid),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -129,7 +129,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Unrecommended value '{0}' in attribute 'index'. Recommended values '{2}'. Table ID '{1}'.", indexValue, tablePid, recommendedIndex),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -154,7 +154,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Untrimmed attribute '{0}' in {1} '{2}'. Current value '{3}'.", "index", "table", tablePid, untrimmedIndex),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,

--- a/Protocol/Error Messages/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
+++ b/Protocol/Error Messages/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
@@ -29,7 +29,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Missing attribute '{0}' in {1} '{2}'.", "index", "table", tablePid),
                 HowToFix = "Add the attribute with value 0.",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,
@@ -54,7 +54,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Empty attribute '{0}' in {1} '{2}'.", "index", "table", tablePid),
                 HowToFix = " Add the attribute with value 0.",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,
@@ -79,7 +79,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Unsupported attribute '{0}' in {1} '{2}'. Current value '{3}'.", "index", "table", tablePid, currentValue),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -104,7 +104,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Reference to non-existing column with IDX '{0}' in attribute 'index'. Table ID '{1}'.", indexValue, tablePid),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -129,7 +129,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Unrecommended value '{0}' in attribute 'index'. Recommended values '{2}'. Table ID '{1}'.", indexValue, tablePid, recommendedIndex),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = false,
 
                 PositionNode = positionNode,
@@ -154,7 +154,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
                 Description = String.Format("Untrimmed attribute '{0}' in {1} '{2}'. Current value '{3}'.", "index", "table", tablePid, untrimmedIndex),
                 HowToFix = "",
                 ExampleCode = "",
-                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "When the table would be a logger table of type DirectConnection, the index needs to be '1'.",
+                Details = "The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'." + Environment.NewLine + "If the table is a logger table of type DirectConnection, the index needs to be '1'.",
                 HasCodeFix = true,
 
                 PositionNode = positionNode,

--- a/Protocol/ErrorMessages.xml
+++ b/Protocol/ErrorMessages.xml
@@ -7550,7 +7550,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[Add the attribute with value 0.]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="2">
 								<Name>EmptyAttribute</Name>
@@ -7569,7 +7569,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[ Add the attribute with value 0.]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="3">
 								<Name>InvalidAttributeValue</Name>
@@ -7589,7 +7589,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="4">
 								<Name>NonExistingColumn</Name>
@@ -7608,7 +7608,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="5">
 								<Name>UnrecommendedValue</Name>
@@ -7628,7 +7628,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="6">
 								<Name>UntrimmedAttribute</Name>
@@ -7648,7 +7648,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="7">
 								<Name>InvalidColumnInterpreteType</Name>

--- a/Protocol/ErrorMessages.xml
+++ b/Protocol/ErrorMessages.xml
@@ -7550,7 +7550,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[Add the attribute with value 0.]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="2">
 								<Name>EmptyAttribute</Name>
@@ -7569,7 +7569,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[ Add the attribute with value 0.]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="3">
 								<Name>InvalidAttributeValue</Name>
@@ -7589,7 +7589,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="4">
 								<Name>NonExistingColumn</Name>
@@ -7608,7 +7608,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="5">
 								<Name>UnrecommendedValue</Name>
@@ -7628,7 +7628,7 @@
 								<HasCodeFix>False</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="6">
 								<Name>UntrimmedAttribute</Name>
@@ -7648,7 +7648,7 @@
 								<HasCodeFix>True</HasCodeFix>
 								<HowToFix><![CDATA[]]></HowToFix>
 								<ExampleCode><![CDATA[]]></ExampleCode>
-								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]When the table would be a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
+								<Details><![CDATA[The value should correspond to one of the column IDXs. '0' (corresponding to the first column) is the recommended value. The referred column should be of Interprete/Type 'string'.[NewLine]If the table is a logger table of type DirectConnection, the index needs to be '1'.]]></Details>
 							</ErrorMessage>
 							<ErrorMessage id="7">
 								<Name>InvalidColumnInterpreteType</Name>

--- a/Protocol/Tests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
+++ b/Protocol/Tests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute.cs
@@ -127,9 +127,11 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
             }
 
             // Unrecommended PK IDX
-            if (index.Value != 0)
+            bool isDirectConnectionLoggerTable = tableParam.Database?.Connection?.Type?.Value == "DirectConnection";
+            int expectedValue = isDirectConnectionLoggerTable ? 1 : 0;
+            if (index.Value != expectedValue)
             {
-                results.Add(Error.UnrecommendedValue(test, tableParam, indexAttribute, indexAttribute.RawValue, tableParam.Id.RawValue, "0"));
+                results.Add(Error.UnrecommendedValue(test, tableParam, indexAttribute, indexAttribute.RawValue, tableParam.Id.RawValue, expectedValue.ToString()));
                 return;
             }
 

--- a/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/CheckIndexAttribute.cs
+++ b/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/CheckIndexAttribute.cs
@@ -29,6 +29,19 @@ namespace ProtocolTests.Protocol.Params.Param.ArrayOptions.CheckIndexAttribute
             Generic.Validate(test, data);
         }
 
+        [TestMethod]
+        public void Param_CheckIndexAttribute_Valid_LoggerTableDirectConnection()
+        {
+            Generic.ValidateData data = new Generic.ValidateData
+            {
+                TestType = Generic.TestType.Valid,
+                FileName = "Valid_LoggerTableDirectConnection",
+                ExpectedResults = new List<IValidationResult>()
+            };
+
+            Generic.Validate(test, data);
+        }
+
         #endregion
 
         #region Invalid Checks
@@ -185,6 +198,7 @@ namespace ProtocolTests.Protocol.Params.Param.ArrayOptions.CheckIndexAttribute
                 ExpectedResults = new List<IValidationResult>
                 {
                     Error.UnrecommendedValue(null, null, null, " 1 ", "1000", "0"),
+                    Error.UnrecommendedValue(null, null, null, "0", "1200", "1"),
                 }
             };
 

--- a/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/Samples/Validate/Invalid/UnrecommendedValue.xml
+++ b/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/Samples/Validate/Invalid/UnrecommendedValue.xml
@@ -8,6 +8,18 @@
 				<ColumnOption idx="1" pid="1002"/>
 			</ArrayOptions>
 		</Param>
+		<Param id="1200">
+			<Name>LoggerTable_DirectConnection</Name>
+			<ArrayOptions index="0">
+				<ColumnOption idx="0" pid="1001"/>
+				<ColumnOption idx="1" pid="1002"/>
+			</ArrayOptions>
+			<Database>
+				<Connection>
+					<Type>DirectConnection</Type>
+				</Connection>
+			</Database>
+		</Param>
 	</Params>
 
 </Protocol>

--- a/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/Samples/Validate/Valid/Valid_LoggerTableDirectConnection.xml
+++ b/ProtocolTests/Protocol/Params/Param/ArrayOptions/CheckIndexAttribute/Samples/Validate/Valid/Valid_LoggerTableDirectConnection.xml
@@ -1,0 +1,69 @@
+﻿<Protocol xmlns="http://www.skyline.be/validatorProtocolUnitTest">
+
+	<Params>
+		<!--Normal tables-->
+		<Param id="1000">
+			<Name>TableSyntax1</Name>
+			<Type id="1001;1002">array</Type>
+			<ArrayOptions index="1"></ArrayOptions>
+			<Database>
+				<Connection>
+					<Type>DirectConnection</Type>
+				</Connection>
+			</Database>
+		</Param>
+		<Param id="1001" duplicateAs="10001">
+			<Name>TableSyntax1_Instance</Name>
+			<Type>read</Type>
+			<Interprete>
+				<Type>string</Type>
+			</Interprete>
+		</Param>
+		<Param id="1002" duplicateAs="10002">
+			<Name>TableSyntax1_Column2</Name>
+			<Type>read</Type>
+			<Interprete>
+				<Type>string</Type>
+			</Interprete>
+		</Param>
+
+		<Param id="1100">
+			<Name>TableSyntax2</Name>
+			<Type>array</Type>
+			<ArrayOptions index="1">
+				<ColumnOption idx="0" pid="1101" />
+				<ColumnOption idx="1" pid="1102" />
+			</ArrayOptions>
+			<Database>
+				<Connection>
+					<Type>DirectConnection</Type>
+				</Connection>
+			</Database>
+		</Param>
+		<Param id="1101">
+			<Name>TableSyntax2_Instance</Name>
+			<Type>read</Type>
+			<Interprete>
+				<Type>string</Type>
+			</Interprete>
+		</Param>
+		<Param id="1102">
+			<Name>TableSyntax2_Column2</Name>
+			<Type>read</Type>
+			<Interprete>
+				<Type>string</Type>
+			</Interprete>
+		</Param>
+
+		<!--View tables-->
+		<Param id="10000">
+			<Name>ViewTable</Name>
+			<Type>array</Type>
+			<ArrayOptions index="0" options=";volatile;view=1000">
+				<ColumnOption idx="0" pid="10001" options=";view=1001" />
+				<ColumnOption idx="1" pid="10002" options=";view=1002" />
+			</ArrayOptions>
+		</Param>
+	</Params>
+
+</Protocol>


### PR DESCRIPTION
- Adapt details on error messages 2.46.1, 2.46.2, 2.46.3, 2.46.4, 2.46.5, 2.46.6
- Changed logic for 2.46.5 to take in account DirectConnection logger tables.

Relevant docs: https://docs.dataminer.services/develop/devguide/Connector/AdvancedLoggerTablesDefiningDirectConnectionTable.html