### PR TITLE
Add trending false exception to history sets warning

### DIFF
--- a/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArray.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArray.cs
@@ -187,6 +187,12 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
                     continue;
                 }
 
+                if (columnParam.Trending?.Value == false)
+                {
+                    // Ignore columns with trending false
+                    continue;
+                }
+
                 // Reference node needs to be param as that's where the Fix needs to happen.
                 results.Add(Error.ParamMissingHistorySet(test, columnParam, qAction, columnParam.Id.RawValue).WithCSharp(callingMethod));
             }

--- a/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArrayNoDelete.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArrayNoDelete.cs
@@ -149,6 +149,12 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
                     continue;
                 }
 
+                if (columnParam.Trending?.Value == false)
+                {
+                    // Ignore columns with trending false
+                    continue;
+                }
+
                 // Reference node needs to be param as that's where the Fix needs to happen.
                 results.Add(Error.ParamMissingHistorySet(test, columnParam, qAction, columnParam.Id.RawValue).WithCSharp(callingMethod));
             }

--- a/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArrayWithColumn.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CSharpSLProtocolFillArrayWithColumn.cs
@@ -249,6 +249,12 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
                 return;
             }
 
+            if (column.Trending?.Value == false)
+            {
+                // Ignore columns with trending false
+                return;
+            }
+
             // Reference node needs to be param as that's where the Fix needs to happen.
             results.Add(Error.ParamMissingHistorySet(test, column, qAction, column.Id.RawValue).WithCSharp(callingMethod));
         }


### PR DESCRIPTION
Using fillarray with history sets should not throw validator issues for the column parameter not having historyset="true" if those column parameters are not trending.