### PR TITLE
feat(ValidatorCompare) Improve Interprete.CheckTypeTag validation

### DIFF
--- a/Protocol/Tests/Protocol/Params/Param/Interprete/Type/CheckTypeTag.cs
+++ b/Protocol/Tests/Protocol/Params/Param/Interprete/Type/CheckTypeTag.cs
@@ -49,7 +49,8 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.Params.Param
 
                 if (newType == null)
                 {
-                    results.Add(ErrorCompare.RemovedTag(newInterprete, newInterprete, newParam.Id?.RawValue));
+                    IReadable referenceNode = (IReadable)newInterprete ?? newParam;
+                    results.Add(ErrorCompare.RemovedTag(referenceNode, referenceNode, newParam.Id?.RawValue));
                     continue;
                 }
 


### PR DESCRIPTION
Check 2.20.2 was not possible to suppress if the entire "Interprete" tag had been removed. To address this the reference node has been changed to be:
- newInterprete: when only the "Type" tag has been removed
- newParam: when the entire "Interprete" tag has been removed