### PR TITLE
False-positive on CheckEndlessLoop (2.24)

### DIFF
--- a/Protocol/Tests/Protocol/CheckEndlessLoop.cs
+++ b/Protocol/Tests/Protocol/CheckEndlessLoop.cs
@@ -221,7 +221,18 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.CheckEndless
                         break;
 
                     case EnumActionOn.Pair:
-                        nextType = ItemTypes.Pair;
+                        EnumActionType[] excludedPairTypes =
+                        {
+                            EnumActionType.Timeout,
+                            EnumActionType.SetNext
+                        };
+
+                        if (!excludedPairTypes.Contains(type))
+                        {
+                            // Continue path if the type is not excluded.
+                            nextType = ItemTypes.Pair;
+                        }
+
                         break;
 
                     case EnumActionOn.Command:

--- a/ProtocolTests/Protocol/CheckEndlessLoop/CheckEndlessLoop.cs
+++ b/ProtocolTests/Protocol/CheckEndlessLoop/CheckEndlessLoop.cs
@@ -59,6 +59,19 @@ namespace ProtocolTests.Protocol.CheckEndlessLoop
             Generic.Validate(check, data);
         }
 
+        [TestMethod]
+        public void Protocol_CheckEndlessLoop_Valid_Collab269212()
+        {
+            Generic.ValidateData data = new Generic.ValidateData
+            {
+                TestType = Generic.TestType.Valid,
+                FileName = "Valid_Collab269212",
+                ExpectedResults = new List<IValidationResult>()
+            };
+
+            Generic.Validate(check, data);
+        }
+
         #endregion
 
         #region Invalid Checks

--- a/ProtocolTests/Protocol/CheckEndlessLoop/Samples/Validate/Valid/Valid_Collab269212.xml
+++ b/ProtocolTests/Protocol/CheckEndlessLoop/Samples/Validate/Valid/Valid_Collab269212.xml
@@ -1,0 +1,57 @@
+﻿<Protocol xmlns="http://www.skyline.be/validatorProtocolUnitTest">
+	<Name>CheckEndlessLoop_PotentialEndlessLoop_Collab269212</Name>
+	<Version>1.0.0.1</Version>
+
+	<Params>
+		<Param id="1116">
+			<Name>Noise_Param_1</Name>
+			<Type>read</Type>
+		</Param>
+		<Param id="1002">
+			<Name>Noise_Param_2</Name>
+			<Type>read</Type>
+		</Param>
+	</Params>
+
+	<Triggers>
+        <Trigger id="127">
+            <On id="1202">command</On>
+            <Time>before</Time>
+            <Type>action</Type>
+            <Content>
+                <Id>70</Id>
+            </Content>
+        </Trigger>
+	</Triggers>
+
+	<Actions>
+        <Action id="70">
+            <On id="1202">pair</On>
+            <Type id="64026">timeout</Type>
+        </Action>
+	</Actions>
+
+	<Groups></Groups>
+
+	<Pairs>
+        <Pair id="1202">
+            <Name>Sweep</Name>
+            <Description></Description>
+            <Content>
+                <Command>1202</Command>
+            </Content>
+        </Pair>
+	</Pairs>
+
+	<Commands>
+        <Command id="1202">
+            <Name>Sweep</Name>
+            <Description></Description>
+            <Content>
+                <!--<Param>1011</Param>-->
+                <Param>1116</Param>
+                <Param>1002</Param>
+            </Content>
+        </Command>
+	</Commands>
+</Protocol>

--- a/Skyline.DataMiner.CICD.Validators.sln.DotSettings
+++ b/Skyline.DataMiner.CICD.Validators.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=autofix/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CICD/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Collab/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=discreets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=interprete/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=partitionedtrending/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
When using an Action with Type 'timeout' or 'set next' On 'pair', then it incorrectly flagged it as an endless loop. These types don't trigger anything, so should be excluded from the check.