### PR TITLE
Update uom.xsd

### DIFF
--- a/Skyline.DataMiner.CICD.Tools.Validator/Resources/uom.xsd
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Resources/uom.xsd
@@ -2114,6 +2114,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="Devices">
+                <xs:annotation>
+                    <xs:documentation>devices</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>devices</slu:name>
+                        <slu:ignoreInDescription>true</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="dF">
                 <xs:annotation>
                     <xs:documentation>decifarad</xs:documentation>
@@ -2690,6 +2699,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     <xs:appinfo>
                         <slu:name>exavolt</slu:name>
                         <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Events">
+                <xs:annotation>
+                    <xs:documentation>events</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>events</slu:name>
+                        <slu:ignoreInDescription>true</slu:ignoreInDescription>
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>


### PR DESCRIPTION
I could see that in EPM system, there are a lot of columns for which devices or events type was used, and validator is suppressed, so I think having these two units available would bring some value. Also, not sure if this is the only place units should be added, but for the easy list maintenance I want to believe that it is.