### PR TITLE
QuickFix - Fix NullReferenceException in CSharpNotifyProtocolNtFillArrayWithColumn

### DIFF
--- a/Protocol/Tests/Protocol/QActions/QAction/CSharpNotifyProtocolNtFillArrayWithColumn.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CSharpNotifyProtocolNtFillArrayWithColumn.cs
@@ -275,6 +275,11 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
 
                 bool? CheckAllowClearOrLeave(Value optional)
                 {
+                    if (optional == null)
+                    {
+                        return null;
+                    }
+
                     if (optional.Type == Value.ValueType.Boolean && optional.HasStaticValue)
                     {
                         return (bool)optional.Object;


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `CheckAllowClearOrLeave` method by adding a null check for the `optional` parameter. This change ensures that the method safely handles cases where `optional` is null, preventing possible runtime errors.

* Added a null check for the `optional` parameter in the `CheckAllowClearOrLeave` method to avoid potential null reference exceptions.