### PR TITLE
Refactor to use Microsoft.Build

### DIFF
--- a/.github/workflows/private-dataminer-cicd-nugetsolution.yml
+++ b/.github/workflows/private-dataminer-cicd-nugetsolution.yml
@@ -1,4 +1,4 @@
-name: DataMiner CICD NuGet Solution
+name: DataMiner CICD Solution
 
 on:
   push:
@@ -13,11 +13,14 @@ on:
 jobs:
 
   CICD:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/NuGet Solution Master Workflow.yml@main
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@MasterWorkflow
     with:
-      sonarCloudProjectName: SkylineCommunications_Skyline.DataMiner.CICD.Validators
+      sonarcloud-project-name: SkylineCommunications_Skyline.DataMiner.CICD.Validators
+      nuget-push-source: https://api.nuget.org/v3/index.json
+      runs-on: windows-latest
+      solution-filter-name: Skyline.DataMiner.CICD.Validators.sln
     secrets:
-      nugetApiKey: ${{ secrets.NUGETAPIKEY }}
+      NUGET_API_KEY: ${{ secrets.NUGETAPIKEY }}
   
   export:
     if: github.ref_type == 'tag' && contains(github.ref_name, '-') == false

--- a/Common.Testing/Common.Testing.csproj
+++ b/Common.Testing/Common.Testing.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0" />
     <PackageReference Include="Skyline.DataMiner.Files.QActionHelper" Version="10.5.2.2" />
   </ItemGroup>
 

--- a/Common.Testing/Common.Testing.csproj
+++ b/Common.Testing/Common.Testing.csproj
@@ -1,21 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Validators.Common.Testing</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
     <PackageReference Include="Skyline.DataMiner.Files.QActionHelper" Version="10.5.2.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.13.9" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.13.9" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.13.9" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.13.9" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Common.Testing/Common.Testing.csproj
+++ b/Common.Testing/Common.Testing.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
     <PackageReference Include="Skyline.DataMiner.Files.QActionHelper" Version="10.5.2.2" />
   </ItemGroup>
 

--- a/Common.Testing/ProtocolTestsHelper.cs
+++ b/Common.Testing/ProtocolTestsHelper.cs
@@ -6,12 +6,12 @@
     using System.Text;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.MSBuild;
+    using Skyline.DataMiner.CICD.Assemblers.Protocol;
     using Skyline.DataMiner.CICD.Models.Common;
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
     using Skyline.DataMiner.CICD.Models.Protocol.Read.Interfaces;
     using Skyline.DataMiner.CICD.Parsers.Common.Xml;
-    using Skyline.DataMiner.CICD.Parsers.Protocol.VisualStudio;
     using Skyline.DataMiner.CICD.Validators.Common.Data;
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;
 

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.Models.Protocol" Version="2.0.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="6.0.0-golf" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Validators.Common</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Validators.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -22,6 +22,7 @@
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.Models.Protocol" Version="2.0.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="6.0.0-bravo" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="5.1.1" />
     <InternalsVisibleTo Include="CommonTests" />
     <InternalsVisibleTo Include="ProtocolTests" />
     <InternalsVisibleTo Include="Skyline.DataMiner.CICD.Validators.Protocol" />

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.Models.Protocol" Version="2.0.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="6.0.0-bravo" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="6.0.0-golf" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommonTests/CommonTests.csproj
+++ b/CommonTests/CommonTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="MSTest" Version="4.0.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="NuGet.Frameworks" Version="7.3.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    </ItemGroup>
+</Project>

--- a/Protocol.Features/Features/10.1/NuGet.cs
+++ b/Protocol.Features/Features/10.1/NuGet.cs
@@ -5,7 +5,7 @@
 
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
 
     using Skyline.DataMiner.CICD.Validators.Protocol.Features.Common;
     using Skyline.DataMiner.CICD.Validators.Protocol.Features.Common.Interfaces;
@@ -31,7 +31,7 @@
             List<IReadable> qActions = new List<IReadable>();
             foreach ((CompiledQActionProject projectData, IQActionsQAction qaction) in context.EachQActionProject())
             {
-                var project = Project.Load(projectData.Project.FilePath, projectData.Project.Name);
+                var project = Project.Load(projectData.Project.FilePath);
 
                 bool packageReferencesFound = project.PackageReferences.Any(IsNotDevPackOrStyleCop);
 

--- a/Protocol.Features/Features/10.2/DotNetFramework.cs
+++ b/Protocol.Features/Features/10.2/DotNetFramework.cs
@@ -5,7 +5,7 @@
 
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     using Skyline.DataMiner.CICD.Validators.Protocol.Features.Common;
     using Skyline.DataMiner.CICD.Validators.Protocol.Features.Common.Attributes;
     using Skyline.DataMiner.CICD.Validators.Protocol.Features.Common.Interfaces;
@@ -34,7 +34,7 @@
             {
                 try
                 {
-                    Project project = Project.Load(projectData.Project.FilePath, projectData.Project.Name);
+                    Project project = Project.Load(projectData.Project.FilePath);
 
                     if (project.TargetFrameworkMoniker == ".NETFramework,Version=v4.6.2" || // SDK style projects
                         project.TargetFrameworkMoniker == ".NETFramework,Version=4.6.2") // Legacy style projects

--- a/Protocol.Features/Protocol.Features.csproj
+++ b/Protocol.Features/Protocol.Features.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protocol.Features/Protocol.Features.csproj
+++ b/Protocol.Features/Protocol.Features.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protocol.Features/Protocol.Features.csproj
+++ b/Protocol.Features/Protocol.Features.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <AssemblyName>Skyline.DataMiner.CICD.Validators.Protocol.Features</AssemblyName>
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="5.1.1" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protocol.FeaturesTests/Initialize.cs
+++ b/Protocol.FeaturesTests/Initialize.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Linq;
     using System.Reflection;
+
+    using Microsoft.Build.Locator;
     using Microsoft.CodeAnalysis.Host.Mef;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -17,6 +19,11 @@
                 // warm up some Roslyn classes, to avoid that unit test fail
                 var defaultServices = MSBuildMefHostServices.DefaultServices;
                 var defaultHost = MefHostServices.DefaultHost;
+
+                if (!MSBuildLocator.IsRegistered)
+                {
+                    MSBuildLocator.RegisterDefaults();
+                }
             }
             catch (ReflectionTypeLoadException tle)
             {

--- a/Protocol.FeaturesTests/Protocol.FeaturesTests.csproj
+++ b/Protocol.FeaturesTests/Protocol.FeaturesTests.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="MSTest" Version="4.0.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protocol.FeaturesTests/Protocol.FeaturesTests.csproj
+++ b/Protocol.FeaturesTests/Protocol.FeaturesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Protocol/Protocol.csproj
+++ b/Protocol/Protocol.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0" />
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
   </ItemGroup>
 

--- a/Protocol/Protocol.csproj
+++ b/Protocol/Protocol.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
   </ItemGroup>
 

--- a/Protocol/Protocol.csproj
+++ b/Protocol/Protocol.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <AssemblyName>Skyline.DataMiner.CICD.Validators.Protocol</AssemblyName>
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
     <PackageReference Include="Skyline.DataMiner.CICD.CSharpAnalysis.Protocol" Version="2.1.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protocol/Tests/Protocol/QActions/CheckAssemblies.cs
+++ b/Protocol/Tests/Protocol/QActions/CheckAssemblies.cs
@@ -5,7 +5,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.Che
 
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;
     using Skyline.DataMiner.CICD.Validators.Common.Model;
     using Skyline.DataMiner.CICD.Validators.Protocol.Common;
@@ -31,7 +31,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.Che
             foreach (CompiledQActionProject compiledQActionProject in context.CompiledQActions.Values)
             {
                 // Load csproj
-                var project = Project.Load(compiledQActionProject.Project.FilePath, compiledQActionProject.Project.Name);
+                var project = Project.Load(compiledQActionProject.Project.FilePath);
 
                 if (!project.PackageReferences.Any())
                 {

--- a/Protocol/Tests/Protocol/QActions/QAction/CSharpCoreInterAppBrokerSupport.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CSharpCoreInterAppBrokerSupport.cs
@@ -20,7 +20,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
     using Skyline.DataMiner.CICD.Validators.Protocol.Helpers;
     using Skyline.DataMiner.CICD.Validators.Protocol.Interfaces;
 
-    using Project = Parsers.Common.VisualStudio.Projects.Project;
+    using Project = Assemblers.Common.VisualStudio.Projects.Project;
 
     [Test(CheckId.CSharpCoreInterAppBrokerSupport, Category.QAction)]
     internal class CSharpCoreInterAppBrokerSupport : IValidate
@@ -38,7 +38,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
             foreach ((IQActionsQAction qaction, SyntaxTree syntaxTree, SemanticModel semanticModel, CompiledQActionProject projectData) in context.EachQActionProjectsAndSyntaxTreesAndModelsAndProjectDatas(true))
             {
                 // Load csproj
-                var project = Project.Load(projectData.Project.FilePath, projectData.Project.Name);
+                var project = Project.Load(projectData.Project.FilePath);
                 if (!project.PackageReferences.Any())
                 {
                     // No NuGet packages being used

--- a/Protocol/Tests/Protocol/QActions/QAction/CheckDataMinerDependency.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CheckDataMinerDependency.cs
@@ -7,7 +7,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
     using Skyline.DataMiner.CICD.Common;
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;
     using Skyline.DataMiner.CICD.Validators.Common.Model;
     using Skyline.DataMiner.CICD.Validators.Protocol.Common;
@@ -33,7 +33,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
             foreach ((CompiledQActionProject projectData, IQActionsQAction qaction) in context.EachQActionProject(true))
             {
                 // Load csproj
-                var project = Project.Load(projectData.Project.FilePath, projectData.Project.Name);
+                var project = Project.Load(projectData.Project.FilePath);
                 if (!project.PackageReferences.Any())
                 {
                     // No NuGet packages being used

--- a/Protocol/Tests/Protocol/QActions/QAction/CheckDeprecatedDllReferences.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CheckDeprecatedDllReferences.cs
@@ -6,7 +6,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
 
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;
     using Skyline.DataMiner.CICD.Validators.Common.Model;
@@ -96,7 +96,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
             foreach ((CompiledQActionProject compiledQActionProject, IQActionsQAction qaction) in context.EachQActionProject(allowBuildErrors: true))
             {
                 // Load csproj of the QAction
-                Project qactionProject = Project.Load(compiledQActionProject.Project.FilePath, compiledQActionProject.Project.Name);
+                Project qactionProject = Project.Load(compiledQActionProject.Project.FilePath);
 
                 string[] referencedDlls = qactionProject.References.Select(reference => reference.GetDllName()).ToArray();
                 foreach (string deprecatedDll in QActionHelper.DeprecatedDlls)

--- a/Protocol/Tests/Protocol/QActions/QAction/CheckFileEncoding.cs
+++ b/Protocol/Tests/Protocol/QActions/QAction/CheckFileEncoding.cs
@@ -9,7 +9,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
     using Skyline.DataMiner.CICD.FileSystem;
     using Skyline.DataMiner.CICD.Models.Protocol;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;
     using Skyline.DataMiner.CICD.Validators.Common.Model;
     using Skyline.DataMiner.CICD.Validators.Protocol.Common;
@@ -34,7 +34,7 @@ namespace Skyline.DataMiner.CICD.Validators.Protocol.Tests.Protocol.QActions.QAc
             {
                 try
                 {
-                    Project project = Project.Load(projectData.Project.FilePath, projectData.Project.Name);
+                    Project project = Project.Load(projectData.Project.FilePath);
                     string projectDirectory = FileSystem.Instance.Path.GetDirectoryName(project.Path);
                     foreach (ProjectFile file in project.Files)
                     {

--- a/ProtocolTests/CheckUnitTests.cs
+++ b/ProtocolTests/CheckUnitTests.cs
@@ -467,15 +467,15 @@
             solution = Roslyn.GetSolution();
 
 #if NETFRAMEWORK
-            valProject = solution.Projects.Single(x => x.Name == "Protocol(netstandard2.0)");
+            valProject = solution.Projects.Single(x => x.Name == "Protocol(net48)");
 #else
-            valProject = solution.Projects.Single(x => x.Name == "Protocol(net8.0)");
+            valProject = solution.Projects.Single(x => x.Name == "Protocol(net10.0)");
 #endif
 
 #if NETFRAMEWORK
             testProject = solution.Projects.Single(x => x.Name == "ProtocolTests" || x.Name == "ProtocolTests(net48)");
-#elif NET8_0
-            testProject = solution.Projects.Single(x => x.Name == "ProtocolTests(net8.0)");
+#elif NET10_0
+            testProject = solution.Projects.Single(x => x.Name == "ProtocolTests(net10.0)");
 #endif
 
             // SDK style projects don't have each file mentioned in the csproj anymore

--- a/ProtocolTests/Initialize.cs
+++ b/ProtocolTests/Initialize.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Reflection;
 
+    using Microsoft.Build.Locator;
     using Microsoft.CodeAnalysis.Host.Mef;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -18,6 +19,11 @@
                 // warm up some Roslyn classes, to avoid that unit test fail
                 var defaultServices = MSBuildMefHostServices.DefaultServices;
                 var defaultHost = MefHostServices.DefaultHost;
+                
+                if (!MSBuildLocator.IsRegistered)
+                {
+                    MSBuildLocator.RegisterDefaults();
+                }
             }
             catch (ReflectionTypeLoadException tle)
             {

--- a/ProtocolTests/ProtocolTests.csproj
+++ b/ProtocolTests/ProtocolTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/ProtocolTests/ProtocolTests.csproj
+++ b/ProtocolTests/ProtocolTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Skyline.DataMiner.CICD.Tools.Validator/Commands/Validate/ValidateProtocolSolutionCommand.cs
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Commands/Validate/ValidateProtocolSolutionCommand.cs
@@ -3,8 +3,8 @@ namespace Skyline.DataMiner.CICD.Tools.Validator.Commands.Validate
     using System.Diagnostics;
     using System.Xml.Linq;
     
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio;
-    using Skyline.DataMiner.CICD.Parsers.Common.VisualStudio.Projects;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio;
+    using Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio.Projects;
     using Skyline.DataMiner.CICD.Tools.Validator.Helpers;
     using Skyline.DataMiner.CICD.Tools.Validator.OutputWriters.Results;
     using Skyline.DataMiner.CICD.Validators.Common.Interfaces;

--- a/Skyline.DataMiner.CICD.Tools.Validator/Program.cs
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Program.cs
@@ -4,7 +4,7 @@ namespace Skyline.DataMiner.CICD.Tools.Validator
     using System.CommandLine.Builder;
     using System.CommandLine.Hosting;
     using System.Threading.Tasks;
-
+    using Microsoft.Build.Locator;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -53,6 +53,11 @@ namespace Skyline.DataMiner.CICD.Tools.Validator
             LogEventLevel level = parseResult.GetValueForOption(isDebug)
                 ? LogEventLevel.Debug
                 : parseResult.GetValueForOption(logLevel);
+
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
 
             var builder = new CommandLineBuilder(rootCommand).UseDefaults().UseHost(host =>
             {

--- a/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
@@ -39,7 +40,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
     <PackageReference Include="Skyline.DataMiner.Core.ArtifactDownloader" Version="3.3.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />

--- a/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -39,11 +39,12 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Parsers.Protocol" Version="5.1.1" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-bravo" />
     <PackageReference Include="Skyline.DataMiner.Core.ArtifactDownloader" Version="3.3.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.31" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
+++ b/Skyline.DataMiner.CICD.Tools.Validator/Skyline.DataMiner.CICD.Tools.Validator.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0-golf" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Assemblers.Protocol" Version="6.0.0" />
     <PackageReference Include="Skyline.DataMiner.Core.ArtifactDownloader" Version="3.3.0" />
     <PackageReference Include="Skyline.DataMiner.XmlSchemas.Protocol" Version="1.1.5" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />

--- a/Skyline.DataMiner.CICD.Validators.sln
+++ b/Skyline.DataMiner.CICD.Validators.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.7.34221.43
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11605.240 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "Common\Common.csproj", "{6C83F73E-1130-46EF-BB3C-67573F987AFE}"
 EndProject
@@ -23,6 +23,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Validator Management Tool",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{05CEF32A-43AD-4D8F-8FA8-AC1A61900AD5}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Skyline.DataMiner.CICD.Validators.sln
+++ b/Skyline.DataMiner.CICD.Validators.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.4.11605.240 stable
+VisualStudioVersion = 18.4.11605.240
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "Common\Common.csproj", "{6C83F73E-1130-46EF-BB3C-67573F987AFE}"
 EndProject
@@ -23,6 +23,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Validator Management Tool",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{05CEF32A-43AD-4D8F-8FA8-AC1A61900AD5}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 	EndProjectSection


### PR DESCRIPTION
### Summary

This PR migrates the solution from `Skyline.DataMiner.CICD.Parsers` to `Skyline.DataMiner.CICD.Assemblers` and upgrades target frameworks from .NET 8 / .NET Standard 2.0 to .NET 10 / .NET Framework 4.8. It also introduces explicit MSBuild Locator registration required by the new Assemblers package.

### Changes

**Target framework upgrades**
- Library projects (`Common`, `Protocol`, `Protocol.Features`): `netstandard2.0;net8.0` → `net48;net10.0`
- Test projects (`CommonTests`, `ProtocolTests`, `Protocol.FeaturesTests`, `Common.Testing`): `net48;net8.0` → `net48;net10.0`
- CLI tool (`Skyline.DataMiner.CICD.Tools.Validator`): `net8.0` → `net10.0`

**Package migration: Parsers → Assemblers**
- Replaced `Skyline.DataMiner.CICD.Parsers.Protocol` v5.1.1 with `Skyline.DataMiner.CICD.Assemblers.Protocol` v6.0.0 across all projects
- Updated namespace references from `Skyline.DataMiner.CICD.Parsers.Common.VisualStudio` to `Skyline.DataMiner.CICD.Assemblers.Common.VisualStudio`
- Adapted `Project.Load()` calls to the new API signature (removed `name` parameter)

**MSBuild integration**
- Added `Microsoft.Build.Locator` v1.11.2 and `MSBuildLocator.RegisterDefaults()` to test initializers and the CLI tool entry point
- Added `Microsoft.Build.*` v17.13.9 packages (net48) and v18.0.2 (net10.0) to `Common.Testing`
- Added `NuGet.Frameworks` v7.3.0 via new `Directory.Build.props` for the entire solution

**CI/CD workflow**
- Switched reusable workflow from `NuGet Solution Master Workflow.yml@main` to `Master Workflow.yml@MasterWorkflow`
- Updated workflow input/secret parameter names to match the new workflow schema

**Solution file**
- Updated Visual Studio version to 18 (VS 2022 → VS 2025)
- Added `.editorconfig` and `Directory.Build.props` to solution items
